### PR TITLE
Including repository link to gradle plugin repo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -137,6 +137,11 @@ If you are using Gradle you need to add a new plugin like this:
 ----
 buildscript {
     ...
+    repositories {
+    	maven {
+	    url "https://plugins.gradle.org/m2/"
+	}
+    }
     dependencies {
         ...
 include::complete/build.gradle[tag=build]


### PR DESCRIPTION
In order to success apply the palantir docker plugin, gradle needs to find the artifact. This change adds the repository information for gradle to successfully find the artifact. Information sourced from https://plugins.gradle.org/plugin/com.palantir.docker